### PR TITLE
create root/.ssh directory if its not there. 

### DIFF
--- a/users/tasks/main.yml
+++ b/users/tasks/main.yml
@@ -14,13 +14,16 @@
 - name: Ensure .ssh directory exists
   file: path=/home/{{wbench_user}}/.ssh state=directory mode=0700
 
-- name: Use interal private key
+- name: Use internal private key
   copy: src=internal_private_key dest=/home/{{wbench_user}}/.ssh/id_rsa mode=0600
   when: not create_key
 
-- name: Use interal public key
+- name: Use internal public key
   copy: src=internal_public_key dest=/home/{{wbench_user}}/.ssh/id_rsa.pub mode=0600
   when: not create_key
+
+- name: create root ssh directory
+  file: path=/root/.ssh state=directory
 
 - name: copy cumulus user's ssh stuff to root.
   command: cp /home/{{ wbench_user}}/.ssh/id_rsa /root/.ssh/id_rsa


### PR DESCRIPTION
bug introduced during recent ravello patches.